### PR TITLE
Reformated files in docs to match github markdown syntax for better readability

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -8,14 +8,16 @@ For a simple example of working with the elements inside a KML file, including e
 
 For more examples, please see the Examples folder in the source code downloads, which includes:
 
-| BalloonFeatures.cs | Displays an information balloon text for all the Features in a KML file. |
-| Change.cs | Shows how KML can be updated by an {{Update}} element, and how to use the {{Process}} extension method to apply the update in code. |
-| Clone.cs | Shows how to copy {{Element}}s (an {{Element}} can only have one parent and throws an exception if you try to add it to another {{Element}}.) |
-| CreateIconStyle.cs | Creates a simple {{IconStyle}}, based on the example given at the [IconStyle documentation](https://developers.google.com/kml/documentation/kmlreference#iconstyle)  |
-| CreateKml.cs | A simple example of creating a KML file from code. |
-| CreateKmz.cs | A simple example of how to create a KMZ file, which is a compressed archive containing a KML file and related resources for that file. |
-| InlineStyles.cs | Uses the {{StyleResolver.InlineStyles}} static method to create a new {{Element}} that has the styles inside the {{Feature}}, instead of using shared styles and specifying a {{StyleUrl}}. |
-| ParseKml.cs | Shows how to use the {{Parser}} class to parse a KML file, ignoring any namespaces declared in the XML. |
-| ShowStyles.cs | Iterates over all the styles in a KML file and displays their names in alphabetical order. |
-| SortPlacemarks.cs | Iterates over the placemarks in a file and displays their names in alphabetical order. |
-| SplitStyles.cs | Moves styles from a Feature to the enclosing Document and then sets the Feature.StyleUrl to reference the new style. |
+| File               | Description                                                                                                                                                                                 |
+|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| BalloonFeatures.cs | Displays an information balloon text for all the Features in a KML file.                                                                                                                    |
+| Change.cs          | Shows how KML can be updated by an `Update` element, and how to use the `Process` extension method to apply the update in code.                                                         |
+| Clone.cs           | Shows how to copy `Element`s (an `Element` can only have one parent and throws an exception if you try to add it to another `Element`.)                                               |
+| CreateIconStyle.cs | Creates a simple `IconStyle`, based on the example given at the [IconStyle documentation](https://developers.google.com/kml/documentation/kmlreference#iconstyle)                         |
+| CreateKml.cs       | A simple example of creating a KML file from code.                                                                                                                                          |
+| CreateKmz.cs       | A simple example of how to create a KMZ file, which is a compressed archive containing a KML file and related resources for that file.                                                      |
+| InlineStyles.cs    | Uses the `StyleResolver.InlineStyles` static method to create a new `Element` that has the styles inside the `Feature`, instead of using shared styles and specifying a `StyleUrl`. |
+| ParseKml.cs        | Shows how to use the `Parser` class to parse a KML file, ignoring any namespaces declared in the XML.                                                                                     |
+| ShowStyles.cs      | Iterates over all the styles in a KML file and displays their names in alphabetical order.                                                                                                  |
+| SortPlacemarks.cs  | Iterates over the placemarks in a file and displays their names in alphabetical order.                                                                                                      |
+| SplitStyles.cs     | Moves styles from a Feature to the enclosing Document and then sets the Feature.StyleUrl to reference the new style.                                                                        |

--- a/docs/Extracting Elements.md
+++ b/docs/Extracting Elements.md
@@ -1,5 +1,5 @@
-A common requirement for processing Kml files is to extract a particular element from the file and then do some processing with them. For example, we might want to extract the {{Polygon}}s from the following Kml:
-{code:xml}
+A common requirement for processing Kml files is to extract a particular element from the file and then do some processing with them. For example, we might want to extract the `Polygon`s from the following Kml:
+```xml
 <?xml version='1.0' encoding='UTF-8'?>
 <kml xmlns='http://www.opengis.net/kml/2.2'>
   <Document>
@@ -36,9 +36,10 @@ A common requirement for processing Kml files is to extract a particular element
     </Placemark>
   </Document>
 </kml>
-{code:xml}
-To do that we can use the {{Flatten}} extension method, which enables us to iterate all the elements and can then filter them out using LINQ, like so:
-{code:c#}
+```
+
+To do that we can use the `Flatten` extension method, which enables us to iterate all the elements and can then filter them out using LINQ, like so:
+```csharp
 using System;
 using System.IO;
 using System.Linq;
@@ -73,4 +74,4 @@ class Program
         Console.ReadKey();
     }
 }
-{code:c#}
+```

--- a/docs/Extracting information from a Kml file.md
+++ b/docs/Extracting information from a Kml file.md
@@ -1,17 +1,17 @@
 The library can be used to load a Kml file in memory and then iterate over its elements. To do this we need to load the file from disk:
 
-{code:c#}
+```csharp
 // This will read a Kml file into memory.
 KmlFile file = KmlFile.Load("YourKmlFile.kml");
 
 // Kmz (compressed Kml files) can also be loaded:
 KmzFile kmz = KmzFile.Open("YourKmzFile.kmz");
 KmlFile file = KmlFile.LoadFromKmz(kmz);
-{code:c#}
+```
 
 Once the file is loaded you can iterate over the elements inside. Here's a quick example that uses Linq:
 
-{code:c#}
+```csharp
 // Make sure these are placed at the top of your file:
 // using System.Linq;
 // using SharpKml.Engine;
@@ -25,4 +25,4 @@ if (kml != null)
         Console.WriteLine(placemark.Name);
     }
 }
-{code:c#}
+```

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -5,34 +5,34 @@ There's an excellent introduction and guide to the Kml language available from G
 First create a new C# console application and copy the SharpKml.dll file (and SharpKml.xml too if you want Intellisense to show you the documentation) into the project directory and add it to the project references.
 
 For a simple Placemark we need to know where it should be, so we'll use a Point as follows:
-{code:c#}
+```csharp
 // This will be the location of the Placemark.
 Point point = new Point();
 point.Coordinate = new Vector(-13.163959, -72.545992);
-{code:c#}
+```
 
 This should hopefully be straight forward; the location is stored as a latitude, longitude in the Coordinate property of the Point element. Now we know where the Placemark will be, let's create it and give it a name:
-{code:c#}
+```csharp
 // This is the Element we are going to save to the Kml file.
 Placemark placemark = new Placemark();
 placemark.Geometry = point;
 placemark.Name = "Machu Picchu";
-{code:c#}
+```
 
 The only thing left to do now is to save it to a Kml file and then we can open it up in a Kml viewer (such as Google Earth). The following will save the Placemark in the application directory in a file called "my placemark.kml":
-{code:c#}
+```csharp
 // This allows us to save an Element easily.
 KmlFile kml = KmlFile.Create(placemark, false);
 using (FileStream stream = File.OpenWrite("my placemark.kml"))
 {
     kml.Save(stream);
 }
-{code:c#}
+```
 
 That's all there is to it, open the file up in your Kml viewer and you'll see a push pin over Machu Picchu, labelled with the text we set in the Placemark.Name property.
 
 Here's the complete code for reference:
-{code:c#}
+```csharp
 using SharpKml.Base;
 using SharpKml.Dom;
 using SharpKml.Engine;
@@ -58,4 +58,4 @@ class Program
         }
     }
 }
-{code:c#}
+```

--- a/docs/Google Earth compatibility.md
+++ b/docs/Google Earth compatibility.md
@@ -1,8 +1,8 @@
-To use some of the advanced features offered by Google Earth in your Kml files (such as a tour) there exists the several classes in the {{SharpKml.Dom.GX}} namespace to help you.
+To use some of the advanced features offered by Google Earth in your Kml files (such as a tour) there exists the several classes in the `SharpKml.Dom.GX` namespace to help you.
 
-However, for the results to display correctly in Google Earth, the Google extension namespace must be added to the root {{kml}} node. Below is a simple example that creates a tour.
+However, for the results to display correctly in Google Earth, the Google extension namespace must be added to the root `kml` node. Below is a simple example that creates a tour.
 
-{{
+```csharp
 using System;
 using System.Reflection;
 using System.Xml;
@@ -29,4 +29,4 @@ class Program
         Console.WriteLine(serializer.Xml);
     }
 }
-}}
+```

--- a/docs/Legacy Files.md
+++ b/docs/Legacy Files.md
@@ -1,39 +1,41 @@
 The OGC KML specification specifies that Kml elements should be inside the `http://www.opengis.com/kml/2.2` namespace. However, before the specification was finalized, programs may have used different namespaces (a common example being `http://earth.google.com/kml/2.2`) and you may need to work with those files. One way of doing this is use a `Parser` as follows:
 
-    using System;
-    using SharpKml.Base;
-    using SharpKml.Dom;
-    using SharpKml.Engine;
+```csharp
+using System;
+using SharpKml.Base;
+using SharpKml.Dom;
+using SharpKml.Engine;
 
-    class Program
+class Program
+{
+    const string Xml =
+        "<kml xmlns='http://earth.google.com/kml/2.2'>" +
+            "<Placemark>" +
+                "<name>SamplePlacemark</name>" +
+            "</Placemark>" +
+        "</kml>";
+
+    static KmlFile ParseLegacyFile()
     {
-        const string Xml =
-            "<kml xmlns='http://earth.google.com/kml/2.2'>" +
-                "<Placemark>" +
-                    "<name>SamplePlacemark</name>" +
-                "</Placemark>" +
-            "</kml>";
+        // Manually parse the Xml
+        Parser parser = new Parser();
+        parser.ParseString(Xml, false); // Ignore the namespaces
 
-        static KmlFile ParseLegacyFile()
-        {
-            // Manually parse the Xml
-            Parser parser = new Parser();
-            parser.ParseString(Xml, false); // Ignore the namespaces
-
-            // The element will be stored in parser.Root - wrap it inside
-            // a KmlFile
-            return KmlFile.Create(parser.Root, true);
-        }
-
-        static void Main(string[]() args)
-        {
-            KmlFile file = ParseLegacyFile();
-
-            // Prove it worked ok
-            Kml kml = (Kml)file.Root;
-            Placemark placemark = (Placemark)kml.Feature;
-            Console.WriteLine(placemark.Name); // Outputs "SamplePlacemark"
-        }
+        // The element will be stored in parser.Root - wrap it inside
+        // a KmlFile
+        return KmlFile.Create(parser.Root, true);
     }
+
+    static void Main(string[]() args)
+    {
+        KmlFile file = ParseLegacyFile();
+
+        // Prove it worked ok
+        Kml kml = (Kml)file.Root;
+        Placemark placemark = (Placemark)kml.Feature;
+        Console.WriteLine(placemark.Name); // Outputs "SamplePlacemark"
+    }
+}
+```
 
 Please note when the file is saved, the OGC namespace will be used, overwriting the original namespace (this is consistent with libkml).


### PR DESCRIPTION
There isn't much to write ;) - I just changed the markdown syntax in a manner, that github shows it in a nicer way than before (mostly changes to tables and codeblocks).