### PR TITLE
Memory improvements

### DIFF
--- a/SharpKml/Base/Parser.cs
+++ b/SharpKml/Base/Parser.cs
@@ -327,12 +327,12 @@ namespace SharpKml.Base
                     // Set default namespace only on unknown elements
                     if (element is UnknownElement)
                     {
-                        element.Namespaces.AddNamespace(string.Empty, this.reader.Value);
+                        element.AddNamespace(string.Empty, this.reader.Value);
                     }
                 }
                 else if (string.Equals("xmlns", this.reader.Prefix, StringComparison.Ordinal))
                 {
-                    element.Namespaces.AddNamespace(this.reader.LocalName, this.reader.Value);
+                    element.AddNamespace(this.reader.LocalName, this.reader.Value);
                 }
                 else
                 {

--- a/SharpKml/Base/Serializer.cs
+++ b/SharpKml/Base/Serializer.cs
@@ -196,7 +196,7 @@ namespace SharpKml.Base
 
             WriteAttributesForElement(writer, element);
 
-            foreach (KeyValuePair<string, string> ns in element.Namespaces.GetNamespacesInScope(XmlNamespaceScope.ExcludeXml))
+            foreach (KeyValuePair<string, string> ns in element.GetNamespaces())
             {
                 writer.WriteAttributeString("xmlns", ns.Key, string.Empty, ns.Value);
                 manager.AddNamespace(ns.Key, ns.Value);

--- a/SharpKml/Dom/Atom/Entry.cs
+++ b/SharpKml/Dom/Atom/Entry.cs
@@ -22,12 +22,19 @@ namespace SharpKml.Dom.Atom
         private Content content;
 
         /// <summary>
+        /// Initializes static members of the <see cref="Entry"/> class.
+        /// </summary>
+        static Entry()
+        {
+            RegisterValidChild<Entry, Category>();
+            RegisterValidChild<Entry, Link>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Entry"/> class.
         /// </summary>
         public Entry()
         {
-            this.RegisterValidChild<Category>();
-            this.RegisterValidChild<Link>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Atom/Feed.cs
+++ b/SharpKml/Dom/Atom/Feed.cs
@@ -19,14 +19,18 @@ namespace SharpKml.Dom.Atom
     [KmlElement("feed", KmlNamespaces.AtomNamespace)]
     public sealed class Feed : Element
     {
+        static Feed()
+        {
+            RegisterValidChild<Feed, Category>();
+            RegisterValidChild<Feed, Entry>();
+            RegisterValidChild<Feed, Link>();
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Feed"/> class.
         /// </summary>
         public Feed()
         {
-            this.RegisterValidChild<Category>();
-            this.RegisterValidChild<Entry>();
-            this.RegisterValidChild<Link>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Element.cs
+++ b/SharpKml/Dom/Element.cs
@@ -23,6 +23,7 @@ namespace SharpKml.Dom
         private readonly List<Element> children = new List<Element>();
         private readonly Dictionary<TypeInfo, int> childTypes = new Dictionary<TypeInfo, int>(); // Will store the type and it's order
         private readonly List<Element> orphans = new List<Element>();
+        private readonly Dictionary<string, string> namespaces = new Dictionary<string, string>();
         private string text = string.Empty;
 
         /// <summary>
@@ -31,7 +32,6 @@ namespace SharpKml.Dom
         protected Element()
         {
             this.Children = new ReadOnlyCollection<Element>(this.children);
-            this.Namespaces = new XmlNamespaceManager(new NameTable());
         }
 
         /// <summary>
@@ -52,11 +52,6 @@ namespace SharpKml.Dom
         /// </summary>
         internal IEnumerable<Element> OrderedChildren =>
             this.children.OrderBy(e => e.GetType().GetTypeInfo(), new ChildTypeComparer(this));
-
-        /// <summary>
-        /// Gets the XML namespaces associated with this instance.
-        /// </summary>
-        internal XmlNamespaceManager Namespaces { get; private set; }
 
         /// <summary>
         /// Gets invalid child Elements found during parsing.
@@ -187,6 +182,26 @@ namespace SharpKml.Dom
             }
 
             return false; // Not ours
+        }
+
+        /// <summary>
+        /// Add an xml namespace to the XML element.
+        /// </summary>
+        /// <param name="prefix">namespace prefix</param>
+        /// <param name="uri">namespace uri</param>
+        protected internal void AddNamespace(string prefix, string uri)
+        {
+            this.namespaces[prefix] = uri;
+        }
+
+        /// <summary>
+        /// Returns namespaces declared for the current Element (excluding the default xml namespace).
+        /// </summary>
+        /// <returns>A IDictionary containing the declared namespaces where Key is namespace prefix and Value namespace uri.</returns>
+        protected internal IDictionary<string, string> GetNamespaces()
+        {
+            return this.namespaces.Where(kvp => kvp.Key != "xml")
+                .ToDictionary(k => k.Key, v => v.Value);
         }
 
         /// <summary>

--- a/SharpKml/Dom/Element.cs
+++ b/SharpKml/Dom/Element.cs
@@ -23,7 +23,7 @@ namespace SharpKml.Dom
         private readonly List<Element> children = new List<Element>();
         private readonly Dictionary<TypeInfo, int> childTypes = new Dictionary<TypeInfo, int>(); // Will store the type and it's order
         private readonly List<Element> orphans = new List<Element>();
-        private readonly StringBuilder text = new StringBuilder();
+        private string text = string.Empty;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Element"/> class.
@@ -71,7 +71,7 @@ namespace SharpKml.Dom
         /// <summary>
         /// Gets the inner text of the XML element.
         /// </summary>
-        protected internal string InnerText => this.text.ToString();
+        protected internal string InnerText => this.text;
 
         /// <summary>
         /// Stores unknown attributes found during parsing for later serialization.
@@ -147,7 +147,7 @@ namespace SharpKml.Dom
         /// </exception>
         protected internal virtual void AddInnerText(string text)
         {
-            this.text.Append(text);
+            this.text += text;
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace SharpKml.Dom
         /// </summary>
         protected void ClearInnerText()
         {
-            this.text.Clear();
+            this.text = string.Empty;
         }
 
         /// <summary>

--- a/SharpKml/Dom/Features/Document.cs
+++ b/SharpKml/Dom/Features/Document.cs
@@ -17,12 +17,19 @@ namespace SharpKml.Dom
     public sealed class Document : Container
     {
         /// <summary>
+        /// Initializes static members of the <see cref="Document"/> class.
+        /// </summary>
+        static Document()
+        {
+            RegisterValidChild<Document, Schema>();
+            RegisterValidChild<Document, Feature>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Document"/> class.
         /// </summary>
         public Document()
         {
-            this.RegisterValidChild<Schema>();
-            this.RegisterValidChild<Feature>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Features/ExtendedData.cs
+++ b/SharpKml/Dom/Features/ExtendedData.cs
@@ -24,12 +24,19 @@ namespace SharpKml.Dom
     public sealed class ExtendedData : Element
     {
         /// <summary>
+        /// Initializes static members of the <see cref="ExtendedData"/> class.
+        /// </summary>
+        static ExtendedData()
+        {
+            RegisterValidChild<ExtendedData, Data>();
+            RegisterValidChild<ExtendedData, SchemaData>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ExtendedData"/> class.
         /// </summary>
         public ExtendedData()
         {
-            this.RegisterValidChild<Data>();
-            this.RegisterValidChild<SchemaData>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Features/Feature.cs
+++ b/SharpKml/Dom/Features/Feature.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Samuel Cragg.
+// Copyright (c) Samuel Cragg.
 //
 // Licensed under the MIT license. See LICENSE file in the project root for
 // full license information.
@@ -30,11 +30,18 @@ namespace SharpKml.Dom
         private AbstractView view;
 
         /// <summary>
+        /// Initializes static members of the <see cref="Feature"/> class.
+        /// </summary>
+        static Feature()
+        {
+            RegisterValidChild<Feature, StyleSelector>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Feature"/> class.
         /// </summary>
         protected Feature()
         {
-            this.RegisterValidChild<StyleSelector>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Features/Folder.cs
+++ b/SharpKml/Dom/Features/Folder.cs
@@ -15,11 +15,18 @@ namespace SharpKml.Dom
     public sealed class Folder : Container
     {
         /// <summary>
+        /// Initializes static members of the <see cref="Folder"/> class.
+        /// </summary>
+        static Folder()
+        {
+            RegisterValidChild<Folder, Feature>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Folder"/> class.
         /// </summary>
         public Folder()
         {
-            this.RegisterValidChild<Feature>();
         }
     }
 }

--- a/SharpKml/Dom/Features/Schema.cs
+++ b/SharpKml/Dom/Features/Schema.cs
@@ -18,12 +18,19 @@ namespace SharpKml.Dom
     public sealed class Schema : KmlObject // TODO: This should inherit from Element, but the C++ version inherits from Object??
     {
         /// <summary>
+        /// Initializes static members of the <see cref="Schema"/> class.
+        /// </summary>
+        static Schema()
+        {
+            RegisterValidChild<Schema, SimpleField>();
+            RegisterValidChild<Schema, GX.SimpleArrayField>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Schema"/> class.
         /// </summary>
         public Schema()
         {
-            this.RegisterValidChild<SimpleField>();
-            this.RegisterValidChild<GX.SimpleArrayField>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Features/SchemaData.cs
+++ b/SharpKml/Dom/Features/SchemaData.cs
@@ -19,12 +19,19 @@ namespace SharpKml.Dom
     public sealed class SchemaData : KmlObject
     {
         /// <summary>
+        /// Initializes static members of the <see cref="SchemaData"/> class.
+        /// </summary>
+        static SchemaData()
+        {
+            RegisterValidChild<SchemaData, SimpleData>();
+            RegisterValidChild<SchemaData, GX.SimpleArrayData>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SchemaData"/> class.
         /// </summary>
         public SchemaData()
         {
-            this.RegisterValidChild<SimpleData>();
-            this.RegisterValidChild<GX.SimpleArrayData>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/GX/MultipleTrack.cs
+++ b/SharpKml/Dom/GX/MultipleTrack.cs
@@ -17,11 +17,18 @@ namespace SharpKml.Dom.GX
     public sealed class MultipleTrack : Geometry
     {
         /// <summary>
+        /// Initializes static members of the <see cref="MultipleTrack"/> class.
+        /// </summary>
+        static MultipleTrack()
+        {
+            RegisterValidChild<MultipleTrack, Track>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MultipleTrack"/> class.
         /// </summary>
         public MultipleTrack()
         {
-            this.RegisterValidChild<Track>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/GX/Playlist.cs
+++ b/SharpKml/Dom/GX/Playlist.cs
@@ -17,11 +17,18 @@ namespace SharpKml.Dom.GX
     public sealed class Playlist : KmlObject
     {
         /// <summary>
+        /// Initializes static members of the <see cref="Playlist"/> class.
+        /// </summary>
+        static Playlist()
+        {
+            RegisterValidChild<Playlist, TourPrimitive>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Playlist"/> class.
         /// </summary>
         public Playlist()
         {
-            this.RegisterValidChild<TourPrimitive>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/GX/SimpleArrayData.cs
+++ b/SharpKml/Dom/GX/SimpleArrayData.cs
@@ -21,11 +21,18 @@ namespace SharpKml.Dom.GX
         private static readonly XmlComponent ValueComponent = new XmlComponent(null, "value", KmlNamespaces.GX22Namespace);
 
         /// <summary>
+        /// Initializes static members of the <see cref="SimpleArrayData"/> class.
+        /// </summary>
+        static SimpleArrayData()
+        {
+            RegisterValidChild<SimpleArrayData, ValueElement>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SimpleArrayData"/> class.
         /// </summary>
         public SimpleArrayData()
         {
-            this.RegisterValidChild<ValueElement>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/GX/Track.cs
+++ b/SharpKml/Dom/GX/Track.cs
@@ -27,13 +27,20 @@ namespace SharpKml.Dom.GX
         private Model model;
 
         /// <summary>
+        /// Initializes static members of the <see cref="Track"/> class.
+        /// </summary>
+        static Track()
+        {
+            RegisterValidChild<Track, WhenElement>();
+            RegisterValidChild<Track, CoordElement>();
+            RegisterValidChild<Track, AnglesElement>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Track"/> class.
         /// </summary>
         public Track()
         {
-            this.RegisterValidChild<WhenElement>();
-            this.RegisterValidChild<CoordElement>();
-            this.RegisterValidChild<AnglesElement>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Geometries/MultipleGeometry.cs
+++ b/SharpKml/Dom/Geometries/MultipleGeometry.cs
@@ -18,11 +18,18 @@ namespace SharpKml.Dom
     public sealed class MultipleGeometry : Geometry
     {
         /// <summary>
+        /// Initializes static members of the <see cref="MultipleGeometry"/> class.
+        /// </summary>
+        static MultipleGeometry()
+        {
+            RegisterValidChild<MultipleGeometry, Geometry>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MultipleGeometry"/> class.
         /// </summary>
         public MultipleGeometry()
         {
-            this.RegisterValidChild<Geometry>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Geometries/Polygon.cs
+++ b/SharpKml/Dom/Geometries/Polygon.cs
@@ -20,11 +20,18 @@ namespace SharpKml.Dom
         private OuterBoundary outer;
 
         /// <summary>
+        /// Initializes static members of the <see cref="Polygon"/> class.
+        /// </summary>
+        static Polygon()
+        {
+            RegisterValidChild<Polygon, InnerBoundary>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Polygon"/> class.
         /// </summary>
         public Polygon()
         {
-            this.RegisterValidChild<InnerBoundary>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Geometries/ResourceMap.cs
+++ b/SharpKml/Dom/Geometries/ResourceMap.cs
@@ -24,11 +24,18 @@ namespace SharpKml.Dom
     public sealed class ResourceMap : KmlObject
     {
         /// <summary>
+        /// Initializes static members of the <see cref="ResourceMap"/> class.
+        /// </summary>
+        static ResourceMap()
+        {
+            RegisterValidChild<ResourceMap, Alias>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ResourceMap"/> class.
         /// </summary>
         public ResourceMap()
         {
-            this.RegisterValidChild<Alias>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Kml.cs
+++ b/SharpKml/Dom/Kml.cs
@@ -76,7 +76,7 @@ namespace SharpKml.Dom
                 throw new ArgumentException("Invalid prefix.", "prefix");
             }
 
-            this.Namespaces.AddNamespace(prefix, uri);
+            this.AddNamespace(prefix, uri);
         }
     }
 }

--- a/SharpKml/Dom/Links/ChangeCollection.cs
+++ b/SharpKml/Dom/Links/ChangeCollection.cs
@@ -19,11 +19,18 @@ namespace SharpKml.Dom
     public sealed class ChangeCollection : Element, ICollection<KmlObject>
     {
         /// <summary>
+        /// Initializes static members of the <see cref="ChangeCollection"/> class.
+        /// </summary>
+        static ChangeCollection()
+        {
+            RegisterValidChild<ChangeCollection, KmlObject>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ChangeCollection"/> class.
         /// </summary>
         public ChangeCollection()
         {
-            this.RegisterValidChild<KmlObject>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Links/CreateCollection.cs
+++ b/SharpKml/Dom/Links/CreateCollection.cs
@@ -20,11 +20,18 @@ namespace SharpKml.Dom
     public sealed class CreateCollection : Element, ICollection<Container>
     {
         /// <summary>
+        /// Initializes static members of the <see cref="CreateCollection"/> class.
+        /// </summary>
+        static CreateCollection()
+        {
+            RegisterValidChild<CreateCollection, Container>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CreateCollection"/> class.
         /// </summary>
         public CreateCollection()
         {
-            this.RegisterValidChild<Container>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Links/DeleteCollection.cs
+++ b/SharpKml/Dom/Links/DeleteCollection.cs
@@ -19,11 +19,18 @@ namespace SharpKml.Dom
     public sealed class DeleteCollection : Element, ICollection<Feature>
     {
         /// <summary>
+        /// Initializes static members of the <see cref="DeleteCollection"/> class.
+        /// </summary>
+        static DeleteCollection()
+        {
+            RegisterValidChild<DeleteCollection, Feature>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DeleteCollection"/> class.
         /// </summary>
         public DeleteCollection()
         {
-            this.RegisterValidChild<Feature>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Links/Update.cs
+++ b/SharpKml/Dom/Links/Update.cs
@@ -26,13 +26,20 @@ namespace SharpKml.Dom
     public sealed class Update : Element
     {
         /// <summary>
+        /// Initializes static members of the <see cref="Update"/> class.
+        /// </summary>
+        static Update()
+        {
+            RegisterValidChild<Update, ChangeCollection>();
+            RegisterValidChild<Update, CreateCollection>();
+            RegisterValidChild<Update, DeleteCollection>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Update"/> class.
         /// </summary>
         public Update()
         {
-            this.RegisterValidChild<ChangeCollection>();
-            this.RegisterValidChild<CreateCollection>();
-            this.RegisterValidChild<DeleteCollection>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Styles/ItemIcon.cs
+++ b/SharpKml/Dom/Styles/ItemIcon.cs
@@ -24,11 +24,18 @@ namespace SharpKml.Dom
         private readonly StateElement state = new StateElement();
 
         /// <summary>
+        /// Initializes static members of the <see cref="ItemIcon"/> class.
+        /// </summary>
+        static ItemIcon()
+        {
+            RegisterValidChild<ItemIcon, StateElement>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ItemIcon"/> class.
         /// </summary>
         public ItemIcon()
         {
-            this.RegisterValidChild<StateElement>();
             this.AddChild(this.state);
         }
 

--- a/SharpKml/Dom/Styles/ListStyle.cs
+++ b/SharpKml/Dom/Styles/ListStyle.cs
@@ -27,11 +27,18 @@ namespace SharpKml.Dom
         public static readonly Color32 DefaultBackgroundColor = new Color32(255, 255, 255, 255);
 
         /// <summary>
+        /// Initializes static members of the <see cref="ListStyle"/> class.
+        /// </summary>
+        static ListStyle()
+        {
+            RegisterValidChild<ListStyle, ItemIcon>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ListStyle"/> class.
         /// </summary>
         public ListStyle()
         {
-            this.RegisterValidChild<ItemIcon>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Styles/StyleMapCollection.cs
+++ b/SharpKml/Dom/Styles/StyleMapCollection.cs
@@ -26,11 +26,18 @@ namespace SharpKml.Dom
     public sealed class StyleMapCollection : StyleSelector, ICollection<Pair>
     {
         /// <summary>
+        /// Initializes static members of the <see cref="StyleMapCollection"/> class.
+        /// </summary>
+        static StyleMapCollection()
+        {
+            RegisterValidChild<StyleMapCollection, Pair>();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="StyleMapCollection"/> class.
         /// </summary>
         public StyleMapCollection()
         {
-            this.RegisterValidChild<Pair>();
         }
 
         /// <summary>

--- a/SharpKml/Dom/Views/AbstractView.cs
+++ b/SharpKml/Dom/Views/AbstractView.cs
@@ -19,12 +19,16 @@ namespace SharpKml.Dom
     {
         private TimePrimitive primitive;
 
+        static AbstractView()
+        {
+            RegisterValidChild<AbstractView, GX.Option>();
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AbstractView"/> class.
         /// </summary>
         protected AbstractView()
         {
-            this.RegisterValidChild<GX.Option>();
         }
 
         /// <summary>


### PR DESCRIPTION
My company uses actively your lib to manage KML files. We are currently running into memory issues with large files (>20k features). I made some "improvements" that I would like to share with you and to get your feedback. Each commit contains a specific memory improvement. Our reference file contains 36000 placemarks associated with some metadata (file size 67.5 MB).

We use Visual Studio 2017 performance profiler to measure memory usage, with our test file and the stock library memory usage is : 847.96 MB

1bcc653 : Element inner text is stored into a StringBuilder, this object is quite heavy and it seems we do not need to build complex strings, so I suggest to use a basic string instead.
Memory usage : 785.72 MB

010a179 : XmlNamespaceManager is a complex object and we do not use all its features. Basicaly what we need is a dictionnary storing the differents namespaces and a way to retreive them excluding the default xml namespace.

Memory usage : 377.23 MB (:+1:)

4a0cb0b : The first two changes were quite simple. This one is a bit more complex and slightly changes the library behaviour. In the current implementation, valid child types are registered for each instances of an Element which implies having a huge number of Dictionaries in memory to store these associations. My suggestion here is to register valid child types in a static manner, so there is only one dictionnary containing an entry for each KML type. This way valid child types are registered once (through the static constructor of each type).

Memory usage : 311.14 MB

I hope I made theses changes the right manner, feel free to contact me if you wan't to discuss anything about this code.

Regards

Sylvain