### PR TITLE
Add KmzFile overloads to use different underlying zip stream

### DIFF
--- a/UnitTests/Engine/KmzFileTest.cs
+++ b/UnitTests/Engine/KmzFileTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Net.Security;
 using System.Reflection;
 using System.Text;
 using NUnit.Framework;
@@ -13,12 +14,36 @@ namespace UnitTests.Engine
     [TestFixture]
     public class KmzFileTest
     {
-        [Test]
-        public void TestBasicOpen()
+        private const int NO_STREAM = 0;
+        private const int FILE_STREAM = 1;
+
+        private Stream[] _streams = new Stream[2] { null, null };
+        private string _tempFile;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            this._tempFile = Path.GetTempFileName();
+            this._streams[FILE_STREAM] = File.Create(this._tempFile);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this._streams[FILE_STREAM].Dispose();
+            if (File.Exists(this._tempFile))
+            {
+                File.Delete(this._tempFile);
+            }
+        }
+        
+        [TestCase(NO_STREAM)]
+        [TestCase(FILE_STREAM)]
+        public void TestBasicOpen(int targetStream)
         {
             // Try a valid archive
             using (var stream = SampleData.CreateStream("Engine.Data.Doc.kmz"))
-            using (var file = KmzFile.Open(stream))
+            using (var file = KmzFile.Open(stream, this._streams[targetStream]))
             {
                 Assert.That(file, Is.Not.Null);
                 var kml = file.ReadKml();
@@ -42,11 +67,12 @@ namespace UnitTests.Engine
             }
         }
 
-        [Test]
-        public void TestDispose()
+        [TestCase(NO_STREAM)]
+        [TestCase(FILE_STREAM)]
+        public void TestDispose(int targetStream)
         {
             // Make sure we can't call any methods after the object has been disposed
-            var file = KmzFile.Create(KmlFile.Create(new Kml(), false));
+            var file = KmzFile.Create(KmlFile.Create(new Kml(), false), this._streams[targetStream]);
             file.Dispose();
 
             // Make sure we can call Dispose more than once
@@ -76,8 +102,9 @@ namespace UnitTests.Engine
             }
         }
 
-        [Test]
-        public void TestList()
+        [TestCase(NO_STREAM)]
+        [TestCase(FILE_STREAM)]
+        public void TestList(int targetStream)
         {
             // Make sure Files returns the entries in the correct order
             string[] expected =
@@ -88,7 +115,7 @@ namespace UnitTests.Engine
             };
 
             using (var stream = SampleData.CreateStream("Engine.Data.MultiKml.kmz"))
-            using (var file = KmzFile.Open(stream))
+            using (var file = KmzFile.Open(stream, this._streams[targetStream]))
             {
                 Assert.That(file.Files.Count(), Is.EqualTo(expected.Length));
 
@@ -100,12 +127,13 @@ namespace UnitTests.Engine
             }
         }
 
-        [Test]
-        public void TestReadFile()
+        [TestCase(NO_STREAM)]
+        [TestCase(FILE_STREAM)]
+        public void TestReadFile(int targetStream)
         {
             // NoKml.kmz has a file called foo.txt in a folder called foo.
             using (var stream = SampleData.CreateStream("Engine.Data.NoKml.kmz"))
-            using (var file = KmzFile.Open(stream))
+            using (var file = KmzFile.Open(stream, this._streams[targetStream]))
             {
                 byte[] data = file.ReadFile("foo/foo.txt");
                 Assert.That(data, Is.Not.Null);
@@ -116,14 +144,15 @@ namespace UnitTests.Engine
             }
         }
 
-        [Test]
-        public void TestReadKml()
+        [TestCase(NO_STREAM)]
+        [TestCase(FILE_STREAM)]
+        public void TestReadKml(int targetStream)
         {
             // Doc.kmz has two Kml files at the root level, a.kml and doc.kml,
             // which were added to the archive in that order. Assert that a.kml
             // is read instead of doc.kml.
             using (var stream = SampleData.CreateStream("Engine.Data.Doc.kmz"))
-            using (var file = KmzFile.Open(stream))
+            using (var file = KmzFile.Open(stream, this._streams[targetStream]))
             {
                 var kml = file.ReadKml();
                 Assert.That(kml.IndexOf("a.kml"), Is.Not.EqualTo(-1)); // Make sure the right file was found
@@ -142,8 +171,9 @@ namespace UnitTests.Engine
             }
         }
 
-        [Test]
-        public void TestSave()
+        [TestCase(NO_STREAM)]
+        [TestCase(FILE_STREAM)]
+        public void TestSave(int targetStream)
         {
             // Create the Kml data
             const string Xml = "<Placemark xmlns='http://www.opengis.net/kml/2.2'><name>tmp kml</name></Placemark>";
@@ -154,7 +184,7 @@ namespace UnitTests.Engine
             using (var stream = new MemoryStream())
             {
                 // Create and save the archive
-                using (var kmz = KmzFile.Create(kml))
+                using (var kmz = KmzFile.Create(kml, this._streams[targetStream]))
                 {
                     kmz.Save(stream);
                 }
@@ -170,10 +200,11 @@ namespace UnitTests.Engine
             }
         }
 
-        [Test]
-        public void TestAddFile()
+        [TestCase(NO_STREAM)]
+        [TestCase(FILE_STREAM)]
+        public void TestAddFile(int targetStream)
         {
-            using (var kmz = CreateArchive())
+            using (var kmz = CreateArchive(this._streams[targetStream]))
             {
                 // Check AddFile handles invalid names correctly
                 byte[] empty = new byte[] { };
@@ -210,10 +241,11 @@ namespace UnitTests.Engine
             }
         }
 
-        [Test]
-        public void TestRemoveFile()
+        [TestCase(NO_STREAM)]
+        [TestCase(FILE_STREAM)]
+        public void TestRemoveFile(int targetStream)
         {
-            using (var kmz = CreateArchive())
+            using (var kmz = CreateArchive(this._streams[targetStream]))
             {
                 Assert.That( kmz.Files.Count(), Is.EqualTo(3));
                 Assert.False(kmz.RemoveFile(null));
@@ -226,10 +258,11 @@ namespace UnitTests.Engine
             }
         }
 
-        [Test]
-        public void TestUpdateFile()
+        [TestCase(NO_STREAM)]
+        [TestCase(FILE_STREAM)]
+        public void TestUpdateFile(int targetStream)
         {
-            using (var kmz = CreateArchive())
+            using (var kmz = CreateArchive(this._streams[targetStream]))
             {
                 Assert.That(kmz.Files.ElementAt(0), Is.EqualTo("doc.kml"));
 
@@ -255,11 +288,12 @@ namespace UnitTests.Engine
             }
         }
 
-        [Test]
-        public void TestReadKmlDoesNotReturnTheBOM()
+        [TestCase(NO_STREAM)]
+        [TestCase(FILE_STREAM)]
+        public void TestReadKmlDoesNotReturnTheBOM(int targetStream)
         {
             const string ExampleString = "Example string with no Byte Order Mark.";
-            KmzFile kmz = KmzFile.Create(KmlFile.Create(new Kml(), duplicates: false));
+            KmzFile kmz = KmzFile.Create(KmlFile.Create(new Kml(), duplicates: false), this._streams[targetStream]);
 
             byte[] data = Encoding.UTF8.GetBytes(ExampleString);
             byte[] bom = Encoding.UTF8.GetPreamble();
@@ -268,14 +302,53 @@ namespace UnitTests.Engine
             string result = kmz.ReadKml();
             Assert.That(result, Is.EqualTo(ExampleString));
         }
+        
+        [TestCase(NO_STREAM)]
+        [TestCase(FILE_STREAM)]
+        public void TestFlush(int targetStream)
+        {
+            using (var kmz = CreateArchive(this._streams[targetStream]))
+            {
+                if (targetStream != NO_STREAM)
+                {
+                    Assert.AreEqual(0, this._streams[targetStream].Length);
+                }
+                Assert.DoesNotThrow(() => kmz.Flush());
+                if (targetStream != NO_STREAM)
+                {
+                    Assert.AreNotEqual(0, this._streams[targetStream].Length);
+                }
+            }
+        }
+        
+        [Test]
+        public void TestCreateWithNotWritableStreamThrowsArgumentException()
+        {
+            using (var stream = new MemoryStream(Array.Empty<byte>(), false))
+            {
+                Assert.That(() => CreateArchive(stream), Throws.TypeOf<ArgumentException>());
+            }
+        }
+        
+        [Test]
+        public void TestCreateWithNotSeekableStreamThrowsNotSupportedException()
+        {
+            using (var innerStream = new MemoryStream())
+            {
+                using (var nonSeekableStream = new SslStream(innerStream))
+                {
+                    Assert.That(() => CreateArchive(nonSeekableStream), Throws.TypeOf<NotSupportedException>());
+                }
+            }
+        }
 
-        private static KmzFile CreateArchive()
+        private static KmzFile CreateArchive(Stream targetStream)
         {
             // Create an empty KmlFile
             var kml = KmlFile.Create(new Kml(), false);
 
             // This adds a "doc.kml" for us
-            var file = KmzFile.Create(kml);
+            var file = KmzFile.Create(kml, targetStream);
 
             // Add a couple more files and return
             file.AddFile("files/new.kml", Encoding.Unicode.GetBytes("new.kml"));


### PR DESCRIPTION
This pull request adds the ability to specify a custom underlying stream for the kmz zip archive. In certain scenarios, such as limited resources, handling huge files, or frequent operations, using `MemoryStream` may not be the best option. Changes can be explicitly flushed by calling the `Flush()` method if needed.